### PR TITLE
Removes Newsletter functionality if no api key assigned (#2659)

### DIFF
--- a/codalab/apps/authenz/forms.py
+++ b/codalab/apps/authenz/forms.py
@@ -35,4 +35,3 @@ class CodalabSignupForm(forms.Form):
             'bibtex': self.cleaned_data['bibtex'],
         })
         new_user.save()
-

--- a/codalab/apps/newsletter/templates/newsletter/base_email.html
+++ b/codalab/apps/newsletter/templates/newsletter/base_email.html
@@ -7,21 +7,9 @@
     <title></title>
 
     <style>
-        /*
-
-        text: #666666
-        links: #739cb9
-
-        palette medium: #7A8D92
-         palette light: #A6C6D1
-          palette teal: #67B8C7
-        */
         html, body {
             background-color: #f7f7f7;
             font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
-        }
-        body {
-            /*padding: 20px;*/
         }
         h1, h2, h3, h4, h5, h6 {
             font-family: "Segoe UI", Segoe, "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -41,7 +29,6 @@
         }
 
         #header {
-            /*background: url("http://{{ site.domain }}{% static "img/slider_exmp_comp.gif" %}");*/
             padding-bottom: 20px;
         }
         #signature {
@@ -55,12 +42,6 @@
     </style>
 </head>
 <body>
-
-<!--
-<div id="header">
-    <img src="http://{{ site.domain }}{% static "img/codalab-logo-white.png" %}" alt="CodaLab Logo">
-</div>
--->
 
 <div id="header">
     <h1>Hello{% if user %} {{ user.username }}{% endif %},</h1>

--- a/codalab/apps/web/templates/account/signup.html
+++ b/codalab/apps/web/templates/account/signup.html
@@ -38,6 +38,15 @@
                 <input id="id_confirmation_key" name="confirmation_key" type="hidden">
             </div>
 
+            {% if USE_MAILCHIMP %}
+            <div class="form-group">
+                <input type='checkbox' id="id_newsletter_opt_in" name='newsletter_opt_in' value="{{ form.newsletter_opt_in.value|default_if_none:"" }}">
+                <label for="id_newsletter_opt_in">I'd like to receive the CodaLab newsletter</label>
+            </div>
+            {% else %}
+                <input type='hidden' id="id_newsletter_opt_in" value="">
+            {% endif %}
+
             <div class="form-group">
                 <input type='checkbox' id="id_newsletter_opt_in" name='newsletter_opt_in' value="{{ form.newsletter_opt_in.value|default_if_none:"" }}">
                 <label for="id_newsletter_opt_in">I'd like to receive the CodaLab newsletter</label>

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -124,6 +124,10 @@
                                     <li><a href="{% url 'user_settings' %}">Settings</a></li>
                                     <li class="divider"></li>
                                     <li><a href="/accounts/password/reset/" target="_self">Change Password</a></li>
+                                    {% if USE_MAILCHIMP %}
+                                        <li class="divider"></li>
+                                        <li><a href="/newsletter/signup/" target="_self">Newsletter</a></li>
+                                    {% endif %}
                                     <li class="divider"></li>
                                     <li><a href="/newsletter/signup/" target="_self">Newsletter</a></li>
                                     <li class="divider"></li>
@@ -131,9 +135,11 @@
                                 </ul>
                             </li>
                         {% else %}
-                            <li>
-                                <a href="/newsletter/signup/" target="_self">Newsletter</a>
-                            </li>
+                            {% if USE_MAILCHIMP %}
+                                <li>
+                                    <a href="/newsletter/signup/" target="_self">Newsletter</a>
+                                </li>
+                            {% endif %}
                             <li>
                                 <a href="{% url 'account_signup' %}?next={{request.path}}" target="_self">Sign Up</a>
                             </li>
@@ -170,7 +176,9 @@
     <footer class="navbar-fixed-bottom">
         <div class="container-fluid">
             <ul class="nav navbar-nav navbar-right">
+            {% if USE_MAILCHIMP %}
             <li><a href="/newsletter/signup/" target="_self">Newsletter</a></li>
+            {% endif %}
                 <li><a href="https://github.com/codalab/codalab/issues" target="_blank">Join us on Github for contact & bug reports</a></li>
                 {% if SINGLE_COMPETITION_VIEW_PK %}
                     <li><a href="http://codalab.org/" target="_blank">Powered by Codalab</a></li>

--- a/codalab/apps/web/templates/web/my/settings.html
+++ b/codalab/apps/web/templates/web/my/settings.html
@@ -108,10 +108,12 @@
                         <th>{{ form.allow_admin_status_updates.label }}</th>
                         <td>{{ form.allow_admin_status_updates }}</td>
                     </tr>
+                    {% if USE_MAILCHIMP %}
                     <tr>
                         <th>{{ form.newsletter_opt_in.label }}</th>
                         <td>{{ form.newsletter_opt_in }}</td>
                     </tr>
+                    {% endif %}
                 </tbody>
             </table>
         </div>

--- a/codalab/codalab/context_processors.py
+++ b/codalab/codalab/context_processors.py
@@ -22,4 +22,5 @@ def common_settings(request):
         'is_dev': codalab_settings.IS_DEV,
         'USE_AWS': codalab_settings.USE_AWS,
         'CODALAB_SITE_DOMAIN': codalab_settings.CODALAB_SITE_DOMAIN,
+        'USE_MAILCHIMP': bool(settings.MAILCHIMP_API_KEY),
     }


### PR DESCRIPTION
* Sets up a mailing list on Mail Chimp that interfaces with the authenz user model as well as the newsletteruser model. Adds a checkbox for users to opt in on signup and in the user settings. Removes users from the mailing list if they are removed in django or opt out of the mailing list.

* Adds tests to make sure users are removed from the mailing list on mailchimp when their status is changed in the newsletterUser model or newsletter_opt_in is set to False.

* Removes all references to Newsletter creation in django and moves that data to the store-newsletters-django branch

* Removes ghost-migrations from django south

* Adds a script in newsletter/scripts to grab all codalab user emails. We can then send an initial newsletter email from that list and allow users to opt in to a newsletter list. This also required splitting the api endpoint based on the audience being all users or newsletter users.

* Adds a check to make sure a user that is not active isn't added to the newsletter. Also adds a test to make sure this is working as expected.

* Fixes a lot of DRY issues, Cruft Removal. Adds links to unsub/sub pages into footer and header. Tests written.

* Addes a check for mailchimp settings on script

* Adds a check in the script to check whether the patch was successful. If not, it will post to mailchimp

* Removes cruft and DRY violations. Adds mocking to the tests. Adds a celery task to resend mailing list items which need retry every 60 minutes. Fixes forms

* Cruft removal, adds new tests, adds a mock get request for checking if the mailchimp servers are up.

* circleCI debug

* circleCI debug

* circleCI debug

* added exception test

* Now checks if codalab has a Mailchimp API Key. If it does, it will allow users to signup and unsubscribe from the mailing list. If not, it will 404 on the mailing list links and remove the ability to edit their opt_in status on account creation and in the user settings.

* Adds context processor for mailing list API key, correctly adds and removes fields based on that variable. Adds a more optimal default 404 return when trying to access the newsletter pages without api key. Gets rid of stale messages in signup/unsubscribe form in newsletters; It was holding all undismissed messages before

* Now uses the default template for 404 page. Removes some cruft and simplifies the boolean check in the context processor. Removes the unneccesary loops in message storage.

* Cruft removal